### PR TITLE
Added/modified 3 lines of code to provide a more descriptive/helpful …

### DIFF
--- a/source/1.15.1.0/GUI/MainMenuActions.cs
+++ b/source/1.15.1.0/GUI/MainMenuActions.cs
@@ -230,7 +230,11 @@ namespace SevenDaysProfileEditor.GUI {
                 }
             }
             else {
-                string text = "You have following developer items in your inventory:\n";
+                // Split the full path into an array where the last element will be the short filename
+                string[] fullPathFileNameArray = fileName.Split('\\');
+                // Capture the short filename from the last element of the array
+                string shortFileName = fullPathFileNameArray[fullPathFileNameArray.Length - 1];
+                string text = string.Format("Player file {0} has the following developer items in their inventory:\n\n", shortFileName);
 
                 for (int i = 0; i < devItems.Count; i++) {
                     text += devItems[i] + "\n";


### PR DESCRIPTION
 Added/modified 3 lines of code to provide a more descriptive/helpful error message when opening a .ttp file that contains one or more dev blocks. Specifically, the new error message specifies the offending file; Very useful when opening more than one file at a time and you want to know which files failed to open.